### PR TITLE
bugfix: decode binary mode string

### DIFF
--- a/fbridge.py
+++ b/fbridge.py
@@ -53,7 +53,7 @@ def listen(fbClient):
             for msg in r.iter_lines():
                 if msg:
                     print(msg)
-                    jmsg = json.loads(msg)
+                    jmsg = json.loads(msg.decode())
                     if jmsg["gateway"] == "":
                         continue
                     


### PR DESCRIPTION
At least on python 3.5, msg was in binary format which resulted in a fatal error.