### PR TITLE
display actual usernames

### DIFF
--- a/fbridge.py
+++ b/fbridge.py
@@ -37,7 +37,9 @@ class FBListener(Client):
         if author_id in users:
             username = users[author_id]
         else:
-            username = author_id
+            u = self.fetchUserInfo(author_id)[author_id]
+            username = u.name
+            users[author_id] = username
 
         ## Set a gateway from the thread_id
         gateway = "FBgateway"


### PR DESCRIPTION
Minor improvement to username output.

I'd like to implement using one channel to handle threaded messages from all facebook users, once we have https://github.com/42wim/matterbridge/pull/627 and/or https://github.com/42wim/matterbridge/issues/638